### PR TITLE
Bug/missing key type check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,6 @@ Fixes # (issue)
 ### Quick checks:
 
 - [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
-- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-s3/pulls) for the same update/change.
+- [ ] There is no other [pull request](https://github.com/gopherslab/conduit-connector-redis/pulls) for the same update/change.
 - [ ] I have written unit tests.
 - [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.

--- a/source/iterator/stream_iterator.go
+++ b/source/iterator/stream_iterator.go
@@ -49,7 +49,6 @@ func NewStreamIterator(ctx context.Context,
 	key string,
 	pollingInterval time.Duration,
 	position sdk.Position) (*StreamIterator, error) {
-
 	keyType, err := redis.String(client.Do("TYPE", key))
 	if err != nil {
 		return nil, fmt.Errorf("error fetching type of key(%s): %w", key, err)

--- a/source/iterator/stream_iterator.go
+++ b/source/iterator/stream_iterator.go
@@ -49,6 +49,18 @@ func NewStreamIterator(ctx context.Context,
 	key string,
 	pollingInterval time.Duration,
 	position sdk.Position) (*StreamIterator, error) {
+
+	keyType, err := redis.String(client.Do("TYPE", key))
+	if err != nil {
+		return nil, fmt.Errorf("error fetching type of key(%s): %w", key, err)
+	}
+	switch keyType {
+	case "none", "stream":
+	// valid key
+	default:
+		return nil, fmt.Errorf("invalid key type: %s, expected none or stream", keyType)
+	}
+
 	tmbWithCtx, _ := tomb.WithContext(ctx)
 	ticker := time.NewTicker(pollingInterval)
 


### PR DESCRIPTION
### Description

This PR adds the missing key type check while initializing the stream iterator in MODE_STREAM for the source connector

Fixes # (issue)

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/gopherslab/conduit-connector-redis/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
